### PR TITLE
Choose git ref or commit using job DSL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/config/GitChangelogConfigHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/config/GitChangelogConfigHelper.java
@@ -22,7 +22,7 @@ import com.google.common.io.CharStreams;
 
 public class GitChangelogConfigHelper {
  public enum FROMTYPE {
-  commit(null), firstCommit(ZERO_COMMIT), master("master"), ref(null);
+  commit("commit"), firstCommit(ZERO_COMMIT), master("master"), ref("ref");
   private final String reference;
 
   FROMTYPE(String ref) {


### PR DESCRIPTION
At the moment you're unable to select a commit or tag/ref option from the job DSL.  Specifically fromType and toType fields.  These equate to the UI 'Choose from reference' and 'Choose to reference' fields.
I believe this change should fix that.