### PR TITLE
Hacktoberfest - Rename jenkins/jnlp-slave -> jenkins/inbound-agent

### DIFF
--- a/docker-slave.sh
+++ b/docker-slave.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo docker run jenkins/jnlp-slave -url http://172.17.0.1:8080/jenkins -workDir=/home/jenkins/agent 430fa1da020e7fca4344d120cfc70f7f1baf9202a6b635a71c1c0f85b617b0d4 mynode
 
+sudo docker run jenkins/inbound-agent -url http://172.17.0.1:8080/jenkins -workDir=/home/jenkins/agent 430fa1da020e7fca4344d120cfc70f7f1baf9202a6b635a71c1c0f85b617b0d4 mynode


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846