### PR TITLE
feat: Support bearer authorization to Jira

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
         <java.level>8</java.level>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <violations.version>1.48</violations.version>
-        <changelog-lib>1.158.4</changelog-lib>
-        <changelog-plugin>1.78</changelog-plugin>
+        <changelog-lib>1.162.0</changelog-lib>
+        <changelog-plugin>1.80</changelog-plugin>
     </properties>
 
     <groupId>de.wellnerbou.jenkins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/GitChangelogDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/GitChangelogDescriptor.java
@@ -41,6 +41,10 @@ public final class GitChangelogDescriptor extends BuildStepDescriptor<Publisher>
     return CredentialsHelper.doFillApiTokenCredentialsIdItems();
   }
 
+  public ListBoxModel doFillJiraBearerCredentialsIdItems() {
+    return CredentialsHelper.doFillApiTokenCredentialsIdItems();
+  }
+
   @Override
   public String getDisplayName() {
     return "Git Changelog";
@@ -85,6 +89,7 @@ public final class GitChangelogDescriptor extends BuildStepDescriptor<Publisher>
     c.setJiraIssuePattern(formData.getString("jiraIssuePattern"));
     c.setJiraUsernamePasswordCredentialsId(formData.getString("jiraUsernamePasswordCredentialsId"));
     c.setJiraBasicAuthStringCredentialsId(formData.getString("jiraBasicAuthStringCredentialsId"));
+    c.setJiraBearerCredentialsId(formData.getString("jiraBearerCredentialsId"));
 
     c.setUseGitHub(formData.getBoolean("useGitHub"));
     c.setGitHubApi(formData.getString("gitHubApi"));

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/config/GitChangelogConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/config/GitChangelogConfig.java
@@ -36,6 +36,8 @@ public class GitChangelogConfig implements Serializable {
   private String jiraUsernamePasswordCredentialsId;
   private String jiraBasicAuthStringCredentialsId;
   private transient String jiraBasicAuthString;
+  private String jiraBearerCredentialsId;
+  private transient String jiraBearer;
   private String noIssueName;
   private String readableTagName;
   private boolean showSummary;
@@ -89,6 +91,7 @@ public class GitChangelogConfig implements Serializable {
       final String jiraUsername,
       final String jiraUsernamePasswordCredentialsId,
       final String jiraBasicAuthStringCredentialsId,
+      final String jiraBearerCredentialsId,
       final String noIssueName,
       final String readableTagName,
       final boolean showSummary,
@@ -132,6 +135,7 @@ public class GitChangelogConfig implements Serializable {
     this.jiraServer = jiraServer;
     this.jiraUsernamePasswordCredentialsId = jiraUsernamePasswordCredentialsId;
     this.jiraBasicAuthStringCredentialsId = jiraBasicAuthStringCredentialsId;
+    this.jiraBearerCredentialsId = jiraBearerCredentialsId;
     this.noIssueName = noIssueName;
     this.readableTagName = readableTagName;
     this.showSummary = showSummary;
@@ -217,6 +221,10 @@ public class GitChangelogConfig implements Serializable {
 
   public String getJiraBasicAuthStringCredentialsId() {
     return jiraBasicAuthStringCredentialsId;
+  }
+
+  public String getJiraBearerCredentialsId() {
+    return jiraBearerCredentialsId;
   }
 
   public String getJiraServer() {
@@ -447,6 +455,11 @@ public class GitChangelogConfig implements Serializable {
   }
 
   @DataBoundSetter
+  public void setJiraBearerCredentialsId(String jiraBearerCredentialsId) {
+    this.jiraBearerCredentialsId = jiraBearerCredentialsId;
+  }
+
+  @DataBoundSetter
   public void setJiraServer(final String jiraServer) {
     this.jiraServer = jiraServer;
   }
@@ -463,6 +476,15 @@ public class GitChangelogConfig implements Serializable {
 
   public String getJiraBasicAuthString() {
     return jiraBasicAuthString;
+  }
+
+  @DataBoundSetter
+  public void setJiraBearer(String jiraBearer) {
+    this.jiraBearer = jiraBearer;
+  }
+
+  public String getJiraBearer() {
+    return jiraBearer;
   }
 
   @DataBoundSetter
@@ -643,6 +665,8 @@ public class GitChangelogConfig implements Serializable {
         + jiraPassword
         + ", jiraBasicAuthStringCredentialsId="
         + jiraBasicAuthStringCredentialsId
+        + ", jiraBearerCredentialsId="
+        + jiraBearerCredentialsId
         + ", jiraServer="
         + jiraServer
         + ", jiraUsername="

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/GitChangelogPerformer.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/GitChangelogPerformer.java
@@ -79,8 +79,17 @@ public class GitChangelogPerformer {
       } else {
         configExpanded.setJiraBasicAuthString(secretString);
       }
+
+      final String getBearerCredentialsId = configExpanded.getJiraBearerCredentialsId();
+      final String secretBearerString = findSecretString(getBearerCredentialsId).orElse(null);
+      if (secretBearerString == null) {
+        listener.getLogger().println("Jira Bearer auth, credential not found!");
+      } else {
+        configExpanded.setJiraBearer(secretBearerString);
+      }
     }
   }
+
   /** Makes sure any Jenkins variable, used in the configuration fields, are evaluated. */
   private static GitChangelogConfig expand(
       final GitChangelogConfig config, final EnvVars environment) {
@@ -108,6 +117,7 @@ public class GitChangelogPerformer {
         environment.expand(config.getJiraBasicAuthStringCredentialsId()));
     c.setJiraUsernamePasswordCredentialsId(
         environment.expand(config.getJiraUsernamePasswordCredentialsId()));
+    c.setJiraBearerCredentialsId(environment.expand(config.getJiraBearerCredentialsId()));
 
     c.setUseGitHub(config.isUseGitHub());
     c.setGitHubApi(environment.expand(config.getGitHubApi()));

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
@@ -78,7 +78,8 @@ public class RemoteCallable extends MasterToSlaveCallable<RemoteResult, IOExcept
             .withJiraIssuePattern(this.config.getJiraIssuePattern()) //
             .withJiraUsername(this.config.getJiraUsername()) //
             .withJiraPassword(this.config.getJiraPassword())
-            .withJiraBasicAuthString(this.config.getJiraBasicAuthString());
+            .withJiraBasicAuthString(this.config.getJiraBasicAuthString())
+            .withJiraBearer(this.config.getJiraBearer());
       }
 
       if (this.config.isUseGitHub()) {

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GitChangelogStep.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GitChangelogStep.java
@@ -411,6 +411,7 @@ public class GitChangelogStep extends Step implements Serializable {
           .withJiraUsername(this.jira.getUsername()) //
           .withJiraPassword(this.jira.getPassword())
           .withJiraBasicAuthString(this.jira.getBasicAuthString());
+          .withJiraBearer(this.jira.getBearer());
     }
     if (this.returnType == CONTEXT) {
       return b.getChangelog();

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GitChangelogStep.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GitChangelogStep.java
@@ -410,7 +410,7 @@ public class GitChangelogStep extends Step implements Serializable {
           .withJiraServer(this.jira.getServer()) //
           .withJiraUsername(this.jira.getUsername()) //
           .withJiraPassword(this.jira.getPassword())
-          .withJiraBasicAuthString(this.jira.getBasicAuthString());
+          .withJiraBasicAuthString(this.jira.getBasicAuthString())
           .withJiraBearer(this.jira.getBearer());
     }
     if (this.returnType == CONTEXT) {

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/JiraConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/JiraConfig.java
@@ -14,6 +14,7 @@ public class JiraConfig extends AbstractDescribableImpl<JiraConfig> implements S
   private final String username;
   private final String password;
   private final String basicAuthString;
+  private final String bearer;
 
   @Extension
   public static class DescriptorImpl extends Descriptor<JiraConfig> {
@@ -30,12 +31,14 @@ public class JiraConfig extends AbstractDescribableImpl<JiraConfig> implements S
       final String issuePattern,
       final String username,
       final String password,
-      final String basicAuthString) {
+      final String basicAuthString,
+      final String bearer) {
     this.server = server;
     this.issuePattern = issuePattern;
     this.username = username;
     this.password = password;
     this.basicAuthString = basicAuthString;
+    this.bearer = bearer;
   }
 
   public String getServer() {
@@ -56,5 +59,9 @@ public class JiraConfig extends AbstractDescribableImpl<JiraConfig> implements S
 
   public String getBasicAuthString() {
     return basicAuthString;
+  }
+
+  public String getBearer() {
+    return bearer;
   }
 }

--- a/src/main/resources/org/jenkinsci/plugins/gitchangelog/GitChangelogRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitchangelog/GitChangelogRecorder/config.jelly
@@ -232,6 +232,10 @@
         <f:entry title="Basic Auth String" field="jiraBasicAuthStringCredentialsId">
           <c:select default="${config.jiraBasicAuthStringCredentialsId}" />
         </f:entry>
+
+        <f:entry title="Personal Access Token" field="jiraBearerCredentialsId">
+          <c:select default="${config.jiraBearerCredentialsId}" />
+        </f:entry>
         
       </f:optionalBlock>
       <f:description>

--- a/src/main/resources/org/jenkinsci/plugins/gitchangelog/steps/config/JiraConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitchangelog/steps/config/JiraConfig/config.jelly
@@ -28,4 +28,10 @@
       <f:password field="basicAuthString"/>
     </f:entry>
 
+    <f:entry title="Personal Access Token">
+      <f:password field="bearer"/>
+      <f:description>
+       Bearer authorization token
+      </f:description>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
It allows set Jira bearer authorization token. 
It was added new property to JiraConfig in same way as is now for Basic Authorization. Related pull request is in git-changelog-lib (https://github.com/tomasbjerre/git-changelog-lib/pull/114) and https://github.com/tomasbjerre/git-changelog-command-line/pull/9 for command line usage

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes

