### PR TITLE
Test with Java 21, simplify dependencies

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,10 @@
-#!groovy
-
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,6 @@
 
     <properties>
         <jenkins.version>2.361.4</jenkins.version>
-        <findbugs.failOnError>false</findbugs.failOnError>
-        <java.level>11</java.level>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <violations.version>1.50.8</violations.version>
         <changelog-lib>1.173.0</changelog-lib>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>2.9.1</version>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <jenkins.version>2.361.4</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <violations.version>1.50.8</violations.version>
-        <changelog-lib>1.173.0</changelog-lib>
+        <changelog-lib>1.174.2</changelog-lib>
         <changelog-plugin>1.98.1</changelog-plugin>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,53 +151,87 @@
             <version>${changelog-lib}</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>guava</artifactId>
-                    <groupId>com.google.guava</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>httpclient</artifactId>
-                    <groupId>org.apache.httpcomponents</groupId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <!-- Newer json-patch provided by token macro plugin -->
+                <exclusion>
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+                <!-- Newer gson provided by JGit from the git client plugin -->
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <!-- JGit dependency provided by git client plugin -->
+                <exclusion>
+                    <groupId>org.eclipse.jgit</groupId>
+                    <artifactId>org.eclipse.jgit</artifactId>
+                </exclusion>
+                <!-- okhttp dependency provided by okhttp plugin -->
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <!-- Jackson API dependencies provided by Jackason API 2 plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.6.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.78.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>antisamy-markup-formatter</artifactId>
-            <version>1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>okhttp-api</artifactId>
         </dependency>
 
         <!-- test // -->
@@ -218,4 +252,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2102.v854b_fec19c92</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.21.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.70</version>
+        <version>4.74</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
         <dependency>
             <artifactId>guava</artifactId>
             <groupId>com.google.guava</groupId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>se.bjurr.gitchangelog</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>git@github.com:jenkinsci/${project.artifactId}-plugin</url>
         <tag>HEAD</tag>

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
@@ -14,10 +14,11 @@ import static se.bjurr.gitchangelog.api.GitChangelogApi.gitChangelogApiBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.net.URISyntaxException;
 import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.jenkinsci.plugins.gitchangelog.config.CustomIssue;
 import org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfig;
 import org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfigHelper.FROMTYPE;
@@ -182,7 +183,10 @@ public class RemoteCallable extends MasterToSlaveCallable<RemoteResult, IOExcept
         write(gitChangelogApiBuilder.render(), toFile, UTF_8);
       }
     } catch (final Throwable e) {
-      logString.append(ExceptionUtils.getStackTrace(e));
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      e.printStackTrace(pw);
+      logString.append(sw.toString());
     }
     remoteResult.setLog(logString.toString());
     return remoteResult;


### PR DESCRIPTION
## Test with Java 21 and simplify dependencies

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

## Pull requests replaced

Supersedes the following pull requests by using the plugin bill of materials to simplify dependency management:

* #83
* #81
* #73

## Other changes

- Remove deprecated properties for java.level and spotbugs
- Use git-changelog latest release 1.174.2
- Use https:// instead of git:// protocol for SCM in pom.xml
- Rely on the guava version provided by Jenkins
- Use assertj 3.24.2 (latest release)
- Use parent pom 4.74
- Use Maven 3.9.5, not 3.8.1
- Use the spotify fmt-maven-plugin
- Remove use of commons-lang3

### Testing done

Confirmed that automated tests pass with Java 21 on Linux.

Created a Pipeline job interactively and confirmed that the changelog string was generated as expected when I performed a checkout and then generated the changelog using the Pipeline syntax snippet generator.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

### Open items

Changing to compile with Java 11 or Java 17 or Java 21 results in the following message at the end of `mvn clean verify`:

```bash
Exception in thread "delete /tmp/jenkins4059485287469992276/plugins" java.lang.NoSuchMethodError: 'void org.apache.commons.logging.LogFactory.release(java.lang.ClassLoader)'
        at hudson.PluginManager.stop(PluginManager.java:1345)
        at org.jvnet.hudson.test.TestPluginManager.reallyStop(TestPluginManager.java:67)
        at org.jvnet.hudson.test.TestPluginManager$1.run(TestPluginManager.java:32)
```

I don't understand the cause of that message.  It appears when building the current Java 8 code on the master branch without any of the changes in this pull request.  Building the master branch with Java 11, Java 17, or Java 21 will report that message without any of the changes in this pull request.
