### PR TITLE
chore(deps): Replace unreleased changelog plugin 2.2.1 with 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <violations.version>2.2.0</violations.version>
         <changelog-lib>2.4.1</changelog-lib>
-        <changelog-plugin>2.2.1</changelog-plugin>
+        <changelog-plugin>2.2.0</changelog-plugin>
     </properties>
 
     <groupId>de.wellnerbou.jenkins</groupId>


### PR DESCRIPTION
## Replace unreleased changelog plugin 2.2.1 with 2.2.0

Builds on the ci.jenkins.io master branch fail with the message:

> Could not find artifact se.bjurr.gitchangelog:git-changelog-maven-plugin:jar:2.2.1

[mvnrepository.com](https://mvnrepository.com/artifact/se.bjurr.gitchangelog/git-changelog-maven-plugin) reports that the most recent release is 2.2.0, not 2.2.1.

Switch to 2.2.0 instead of 2.2.1

### Testing done

Compilation fails before this change and passes after this change on my recently installed Fedora Linux 41.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
