### PR TITLE
Require Jenkins 2.479.1 or newer and Jakarta EE 9

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/debug.sh
+++ b/debug.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 mvn versions:update-properties
-mvnDebug hpi:run -Djava.util.logging.config.file=logging.properties -Djenkins.version=2.462.1 -Denforcer.skip=true
+mvnDebug hpi:run -Djava.util.logging.config.file=logging.properties -Djenkins.version=2.479.3 -Denforcer.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,14 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.87</version>
+        <version>5.9</version>
         <relativePath />
     </parent>
 
     <properties>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.462</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <violations.version>2.2.0</violations.version>
         <changelog-lib>2.6.0</changelog-lib>
@@ -110,7 +109,7 @@
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
 
@@ -200,6 +199,18 @@
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-tree</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -273,7 +284,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3358.vea_fa_1f41504d</version>
+                <version>4440.v39a_9eb_b_c6b_4d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 ./mvnw versions:update-properties
-./mvnw hpi:run -Djava.util.logging.config.file=logging.properties -Djenkins.version=2.462.1 -Denforcer.skip=true
+./mvnw hpi:run -Djava.util.logging.config.file=logging.properties -Djenkins.version=2.479.3 -Denforcer.skip=true

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/GitChangelogDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/GitChangelogDescriptor.java
@@ -12,7 +12,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.gitchangelog.config.CredentialsHelper;
 import org.jenkinsci.plugins.gitchangelog.config.CustomIssue;
 import org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfig;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public final class GitChangelogDescriptor extends BuildStepDescriptor<Publisher> {
   private GitChangelogConfig config;
@@ -75,7 +75,7 @@ public final class GitChangelogDescriptor extends BuildStepDescriptor<Publisher>
   }
 
   @Override
-  public Publisher newInstance(final StaplerRequest req, final JSONObject formData)
+  public Publisher newInstance(final StaplerRequest2 req, final JSONObject formData)
       throws hudson.model.Descriptor.FormException {
     final GitChangelogConfig c = new GitChangelogConfig();
     c.setUseConfigFile(formData.getBoolean("useConfigFile"));

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/config/CustomIssue.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/config/CustomIssue.java
@@ -1,9 +1,11 @@
 package org.jenkinsci.plugins.gitchangelog.config;
 
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class CustomIssue implements Serializable {
+  @Serial
   private static final long serialVersionUID = -6202256680695752956L;
   private String link;
   private String name;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/config/GitChangelogConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/config/GitChangelogConfig.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitchangelog.config;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -8,6 +9,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 public class GitChangelogConfig implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = -6715117454282183133L;
   private String configFile;
   private String createFileTemplateContent;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
@@ -11,7 +11,6 @@ import static org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfigHelper
 import static org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfigHelper.FROMTYPE.ref;
 import static se.bjurr.gitchangelog.api.GitChangelogApi.gitChangelogApiBuilder;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -19,6 +18,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import jenkins.security.MasterToSlaveCallable;
+import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.gitchangelog.config.CustomIssue;
 import org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfig;
 import org.jenkinsci.plugins.gitchangelog.config.GitChangelogConfigHelper.FROMTYPE;
@@ -41,7 +41,6 @@ public class RemoteCallable extends MasterToSlaveCallable<RemoteResult, IOExcept
   }
 
   @Override
-  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
   public RemoteResult call() throws IOException {
     final RemoteResult remoteResult = new RemoteResult();
     final StringBuilder logString = new StringBuilder();
@@ -179,7 +178,7 @@ public class RemoteCallable extends MasterToSlaveCallable<RemoteResult, IOExcept
         logString.append("Creating changelog ").append(this.config.toFile());
 
         final File toFile = new File(this.workspacePath + "/" + this.config.toFile());
-        new File(toFile.getParent()).mkdirs();
+        FileUtils.forceMkdir(new File(toFile.getParent()));
         write(gitChangelogApiBuilder.render(), toFile, UTF_8);
       }
     } catch (final Throwable e) {

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteCallable.java
@@ -14,6 +14,7 @@ import static se.bjurr.gitchangelog.api.GitChangelogApi.gitChangelogApiBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
@@ -28,6 +29,7 @@ import se.bjurr.gitchangelog.api.GitChangelogApi;
 public class RemoteCallable extends MasterToSlaveCallable<RemoteResult, IOException>
     implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = -2489061314794088231L;
   private final GitChangelogConfig config;
   private String path = "";
@@ -185,7 +187,7 @@ public class RemoteCallable extends MasterToSlaveCallable<RemoteResult, IOExcept
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw);
       e.printStackTrace(pw);
-      logString.append(sw.toString());
+      logString.append(sw);
     }
     remoteResult.setLog(logString.toString());
     return remoteResult;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteResult.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/perform/RemoteResult.java
@@ -1,9 +1,11 @@
 package org.jenkinsci.plugins.gitchangelog.perform;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class RemoteResult implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 8363216067945804103L;
   private String leftSideTitle;
   private String leftSideUrl;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GetHighestSemanticVersionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GetHighestSemanticVersionStep.java
@@ -10,6 +10,7 @@ import static se.bjurr.gitchangelog.api.GitChangelogApi.gitChangelogApiBuilder;
 import hudson.Extension;
 import hudson.FilePath;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.text.ParseException;
 import jenkins.security.MasterToSlaveCallable;
@@ -25,6 +26,7 @@ import se.bjurr.gitchangelog.api.exceptions.GitChangelogRepositoryException;
 
 public class GetHighestSemanticVersionStep extends Step implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 795555442767777209L;
   private String repo;
 
@@ -81,26 +83,28 @@ public class GetHighestSemanticVersionStep extends Step implements Serializable 
 
   @Override
   public StepExecution start(final StepContext context) {
-    return new SynchronousNonBlockingStepExecution<Object>(context) {
+    return new SynchronousNonBlockingStepExecution<>(context) {
 
-      private static final long serialVersionUID = 1L;
+        @Serial
+        private static final long serialVersionUID = 1L;
 
-      @Override
-      protected Object run() throws Exception {
-        final FilePath workspace = context.get(FilePath.class);
+        @Override
+        protected Object run() throws Exception {
+            final FilePath workspace = context.get(FilePath.class);
 
-        final MasterToSlaveCallable<Object, Exception> callable =
-            new MasterToSlaveCallable<Object, Exception>() {
-              private static final long serialVersionUID = 1L;
+            final MasterToSlaveCallable<Object, Exception> callable =
+                    new MasterToSlaveCallable<>() {
+                        @Serial
+                        private static final long serialVersionUID = 1L;
 
-              @Override
-              public Object call() throws Exception {
-                return GetHighestSemanticVersionStep.this.perform(workspace);
-              }
-            };
+                        @Override
+                        public Object call() throws Exception {
+                            return GetHighestSemanticVersionStep.this.perform(workspace);
+                        }
+                    };
 
-        return workspace.act(callable);
-      }
+            return workspace.act(callable);
+        }
     };
   }
 

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GetNextSemanticVersionStep.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GetNextSemanticVersionStep.java
@@ -10,6 +10,7 @@ import static se.bjurr.gitchangelog.api.GitChangelogApi.gitChangelogApiBuilder;
 import hudson.Extension;
 import hudson.FilePath;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.text.ParseException;
 import jenkins.security.MasterToSlaveCallable;
@@ -25,6 +26,7 @@ import se.bjurr.gitchangelog.api.exceptions.GitChangelogRepositoryException;
 
 public class GetNextSemanticVersionStep extends Step implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 795555442767777209L;
   private String repo;
 
@@ -112,26 +114,28 @@ public class GetNextSemanticVersionStep extends Step implements Serializable {
 
   @Override
   public StepExecution start(final StepContext context) {
-    return new SynchronousNonBlockingStepExecution<Object>(context) {
+    return new SynchronousNonBlockingStepExecution<>(context) {
 
-      private static final long serialVersionUID = 1L;
+        @Serial
+        private static final long serialVersionUID = 1L;
 
-      @Override
-      protected Object run() throws Exception {
-        final FilePath workspace = context.get(FilePath.class);
+        @Override
+        protected Object run() throws Exception {
+            final FilePath workspace = context.get(FilePath.class);
 
-        final MasterToSlaveCallable<Object, Exception> callable =
-            new MasterToSlaveCallable<Object, Exception>() {
-              private static final long serialVersionUID = 1L;
+            final MasterToSlaveCallable<Object, Exception> callable =
+                    new MasterToSlaveCallable<>() {
+                        @Serial
+                        private static final long serialVersionUID = 1L;
 
-              @Override
-              public Object call() throws Exception {
-                return GetNextSemanticVersionStep.this.perform(workspace);
-              }
-            };
+                        @Override
+                        public Object call() throws Exception {
+                            return GetNextSemanticVersionStep.this.perform(workspace);
+                        }
+                    };
 
-        return workspace.act(callable);
-      }
+            return workspace.act(callable);
+        }
     };
   }
 

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GitChangelogStep.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/GitChangelogStep.java
@@ -14,6 +14,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -45,6 +46,7 @@ import se.bjurr.gitchangelog.api.exceptions.GitChangelogRepositoryException;
 
 public class GitChangelogStep extends Step implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 795555442767777209L;
   private RETURN_TYPE returnType;
   private String template;
@@ -336,26 +338,28 @@ public class GitChangelogStep extends Step implements Serializable {
 
   @Override
   public StepExecution start(final StepContext context) {
-    return new SynchronousNonBlockingStepExecution<Object>(context) {
+    return new SynchronousNonBlockingStepExecution<>(context) {
 
-      private static final long serialVersionUID = 1L;
+        @Serial
+        private static final long serialVersionUID = 1L;
 
-      @Override
-      protected Object run() throws Exception {
-        final FilePath workspace = context.get(FilePath.class);
+        @Override
+        protected Object run() throws Exception {
+            final FilePath workspace = context.get(FilePath.class);
 
-        final MasterToSlaveCallable<Object, Exception> callable =
-            new MasterToSlaveCallable<Object, Exception>() {
-              private static final long serialVersionUID = 1L;
+            final MasterToSlaveCallable<Object, Exception> callable =
+                    new MasterToSlaveCallable<>() {
+                        @Serial
+                        private static final long serialVersionUID = 1L;
 
-              @Override
-              public Object call() throws Exception {
-                return GitChangelogStep.this.perform(workspace);
-              }
-            };
+                        @Override
+                        public Object call() throws Exception {
+                            return GitChangelogStep.this.perform(workspace);
+                        }
+                    };
 
-        return workspace.act(callable);
-      }
+            return workspace.act(callable);
+        }
     };
   }
 

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/CustomIssueConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/CustomIssueConfig.java
@@ -4,12 +4,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 public class CustomIssueConfig extends AbstractDescribableImpl<CustomIssueConfig>
     implements Serializable {
+  @Serial
   private static final long serialVersionUID = 8842918044772949798L;
   private final String name;
   private final String issuePattern;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/ExtendedVariableConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/ExtendedVariableConfig.java
@@ -4,11 +4,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class ExtendedVariableConfig extends AbstractDescribableImpl<ExtendedVariableConfig>
     implements Serializable {
+  @Serial
   private static final long serialVersionUID = 8842918044772949798L;
   private final String name;
   private final String value;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/GitHubConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/GitHubConfig.java
@@ -4,11 +4,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GitHubConfig extends AbstractDescribableImpl<GitHubConfig> implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 6697975254396703929L;
   private final String api;
   private final String token;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/GitLabConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/GitLabConfig.java
@@ -4,10 +4,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class GitLabConfig extends AbstractDescribableImpl<GitLabConfig> implements Serializable {
+  @Serial
   private static final long serialVersionUID = -8851592658630679192L;
   private final String server;
   private final String token;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/JiraConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/JiraConfig.java
@@ -4,10 +4,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class JiraConfig extends AbstractDescribableImpl<JiraConfig> implements Serializable {
+  @Serial
   private static final long serialVersionUID = -2407705524441526456L;
   private final String server;
   private final String issuePattern;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/RedmineConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/RedmineConfig.java
@@ -4,10 +4,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class RedmineConfig extends AbstractDescribableImpl<RedmineConfig> implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1038551646703386319L;
   private final String server;
   private final String issuePattern;

--- a/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/RefConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/gitchangelog/steps/config/RefConfig.java
@@ -5,12 +5,15 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.ListBoxModel;
+
+import java.io.Serial;
 import java.io.Serializable;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class RefConfig extends AbstractDescribableImpl<RefConfig> implements Serializable {
+  @Serial
   private static final long serialVersionUID = -7003493790467059304L;
   private final REF_TYPE type;
   private final String value;


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
